### PR TITLE
Whitelist of sample test is required as of Php 7.1 and PhpUnit 6.4

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,4 +11,9 @@
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="true">
+			<file>./sample-plugin.php</file>
+		</whitelist>
+	</filter>
 </phpunit>


### PR DESCRIPTION
Whitelist of sample test is required as of Php 7.1 and PhpUnit 6.4. Otherwise PhpStorm / PhpUnit will give you an error, that CodeCoverage report won't be generated. Tried, this solves the issue. For further reading: https://phpunit.de/manual/current/en/appendixes.configuration.html#appendixes.configuration.whitelisting-files