### PR TITLE
Fix loading order

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,9 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';
+
 /**
  * Manually load the plugin being tested.
  */
@@ -26,6 +29,3 @@ function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/sample-plugin.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
-
-// Start up the WP testing environment.
-require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
Make WordPress functions available before loading the plugin to avoid errors for plugins which require wordpress funcions on load